### PR TITLE
Build/make scripts

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -137,6 +137,20 @@ define COMPILE_CXX_CMDS
 	 rm -f ${@:%$(suffix $@)=%.d}
 endef
 
+# COMPILE_CUDA_CMDS - Commands for compiling CUDA source code.
+define COMPILE_CUDA_CMDS
+    @mkdir -p $(dir $@)
+        $(strip ${NVCC} -o $(basename $@).d -M ${CUDAFLAGS} ${SRC_CUDAFLAGS} ${INCDIRS} \
+            ${SRC_INCDIRS} ${SRC_DEFS} ${DEFS} $<)    
+        $(strip ${NVCC} -o $@ -c ${CUDAFLAGS} ${SRC_CUDAFLAGS} ${INCDIRS} \
+            ${SRC_INCDIRS} ${SRC_DEFS} ${DEFS} $<)
+        @cp ${@:%$(suffix $@)=%.d} ${@:%$(suffix $@)=%.P}; \
+             sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+                 -e '/^$$/ d' -e 's/$$/ :/' < ${@:%$(suffix $@)=%.d} \
+                 >> ${@:%$(suffix $@)=%.P}; \
+        rm -f ${@:%$(suffix $@)=%.d}
+endef
+
 # INCLUDE_SUBMAKEFILE - Parameterized "function" that includes a new
 #   "submakefile" fragment into the overall Makefile. It also recursively
 #   includes all submakefiles of the specified submakefile fragment.
@@ -149,6 +163,7 @@ define INCLUDE_SUBMAKEFILE
     TARGET        :=
     TGT_CFLAGS    :=
     TGT_CXXFLAGS  :=
+    TGT_CUDAFLAGS := 
     TGT_DEFS      :=
     TGT_INCDIRS   :=
     TGT_LDFLAGS   :=
@@ -161,6 +176,7 @@ define INCLUDE_SUBMAKEFILE
     SOURCES       :=
     SRC_CFLAGS    :=
     SRC_CXXFLAGS  :=
+    SRC_CUDAFLAGS := 
     SRC_DEFS      :=
     SRC_INCDIRS   :=
 
@@ -187,6 +203,7 @@ define INCLUDE_SUBMAKEFILE
         ALL_TGTS += $${TGT}
         $${TGT}_CFLAGS    := $${TGT_CFLAGS}
         $${TGT}_CXXFLAGS  := $${TGT_CXXFLAGS}
+        $${TGT}_CUDAFLAGS := $${TGT_CUDAFLAGS}
         $${TGT}_DEFS      := $${TGT_DEFS}
         $${TGT}_DEPS      :=
         TGT_INCDIRS       := $$(call QUALIFY_PATH,$${DIR},$${TGT_INCDIRS})
@@ -206,6 +223,7 @@ define INCLUDE_SUBMAKEFILE
         TGT := $$(strip $$(call PEEK,$${TGT_STACK}))
         $${TGT}_CFLAGS    += $${TGT_CFLAGS}
         $${TGT}_CXXFLAGS  += $${TGT_CXXFLAGS}
+        $${TGT}_CUDAFLAGS += $${TGT_CUDAFLAGS}
         $${TGT}_DEFS      += $${TGT_DEFS}
         TGT_INCDIRS       := $$(call QUALIFY_PATH,$${DIR},$${TGT_INCDIRS})
         TGT_INCDIRS       := $$(call CANONICAL_PATH,$${TGT_INCDIRS})
@@ -249,6 +267,7 @@ define INCLUDE_SUBMAKEFILE
         $${TGT}_DEPS += $${OBJS:%.o=%.P}
         $${OBJS}: SRC_CFLAGS   := $${$${TGT}_CFLAGS} $${SRC_CFLAGS}
         $${OBJS}: SRC_CXXFLAGS := $${$${TGT}_CXXFLAGS} $${SRC_CXXFLAGS}
+        $${OBJS}: SRC_CUDAFLAGS := $${$${TGT}_CUDAFLAGS} $${SRC_CUDAFLAGS}
         $${OBJS}: SRC_DEFS     := $$(addprefix -D,$${$${TGT}_DEFS} $${SRC_DEFS})
         $${OBJS}: SRC_INCDIRS  := $$(addprefix -I,\
                                      $${$${TGT}_INCDIRS} $${SRC_INCDIRS})
@@ -328,8 +347,9 @@ endif
 # Define the source file extensions that we know how to handle.
 C_SRC_EXTS := %.c
 CXX_SRC_EXTS := %.C %.cc %.cp %.cpp %.CPP %.cxx %.c++
+CUDA_SRC_EXTS := %.cu 
 JAVA_EXTS    := %.jar %.tar
-ALL_SRC_EXTS := ${C_SRC_EXTS} ${CXX_SRC_EXTS} ${JAVA_EXTS}
+ALL_SRC_EXTS := ${C_SRC_EXTS} ${CXX_SRC_EXTS} ${JAVA_EXTS} ${CUDA_SRC_EXTS} 
 
 # Initialize global variables.
 ALL_TGTS :=
@@ -337,6 +357,10 @@ DEFS :=
 DIR_STACK :=
 INCDIRS :=
 TGT_STACK :=
+
+# Define an implicit rule to make CUDA files
+%.o : %.cu
+	$(NVCC) -c $(CUDAFLAGS) $< -o $@ 
 
 # (BPW) Discover our OS and architecture.  These are used to set the BUILD_DIR and TARGET_DIR to
 # something more useful than 'build' and '.'.
@@ -396,6 +420,12 @@ $(foreach TGT,${ALL_TGTS},\
   $(foreach EXT,${CXX_SRC_EXTS},\
     $(eval $(call ADD_OBJECT_RULE,${BUILD_DIR}/$(call CANONICAL_PATH,${TGT}),\
              ${EXT},$${COMPILE_CXX_CMDS}))))
+
+# Add pattern rule(s) for creating compiled object code from CUDA sources. 
+$(foreach TGT,${ALL_TGTS},\
+  $(foreach EXT,${CUDA_SRC_EXTS},\
+    $(eval $(call ADD_OBJECT_RULE,${BUILD_DIR}/$(call CANONICAL_PATH,${TGT}),\
+             ${EXT},$${COMPILE_CUDA_CMDS}))))
 
 # Add "clean" rules to remove all build-generated files.
 .PHONY: clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -366,16 +366,6 @@ endif
 ${info Building for '${OSTYPE}' '${OSVERSION}' as '${MACHINETYPE}'}
 #${info Using LD_RUN_PATH '${LD_RUN_PATH}'}
 
-ifeq ($(BUILDDEBUG), 1)
-	CXXFLAGS = -D_GLIBCXX_PARALLEL -pthread -O0 -Wall -g -fopenmp
-	CFLAGS = -D_GLIBCXX_PARALLEL -pthread -O0 -Wall -g -fopenmp
-else
-	CXXFLAGS = -D_GLIBCXX_PARALLEL -pthread -O3 -Wall
-	CFLAGS = -D_GLIBCXX_PARALLEL -pthread -O3 -Wall
-endif
-
-LDFLAGS = -pthread -lm -fopenmp
-
 
 # Include the main user-supplied submakefile. This also recursively includes
 # all other user-supplied submakefiles.

--- a/src/common/defs.h
+++ b/src/common/defs.h
@@ -18,7 +18,7 @@ typedef int64_t     i8_t;
 typedef uint64_t    u8_t;
 typedef i8_t        idx_t;
 
-typedef u1_t		uint1;
+//typedef u1_t		uint1;
 typedef idx_t		index_t;
 
 #define INVALID_IDX (-1)

--- a/src/common/packed_db.h
+++ b/src/common/packed_db.h
@@ -36,7 +36,7 @@ public:
 		{
 			for (index_t i = 0; i < size; ++i)
 			{
-				uint1 c = get_char(offset + i);
+				u1_t c = get_char(offset + i);
 				seq[idx++] = c;
 			}
 		}
@@ -44,7 +44,7 @@ public:
 		{
 			for (index_t i = size - 1; i >= 0; --i)
 			{
-				uint1 c = get_char(offset + i);
+				u1_t c = get_char(offset + i);
 				c = 3 - c;
 				seq[idx++] = c;
 			}

--- a/src/main.mk
+++ b/src/main.mk
@@ -6,6 +6,7 @@ ifeq "$(strip ${TARGET_DIR})" ""
 endif
 
 TARGET       := libmecat.a
+SRC_CXXFLAGS := -pthread -fopenmp -D_GLIBCXX_PARALLEL 
 
 SOURCES      := common/alignment.cpp \
 		common/buffer_line_iterator.cpp \
@@ -24,4 +25,5 @@ SRC_INCDIRS  := common \
 SUBMAKEFILES := mecat2pw/pw.mk \
 		mecat2ref/mecat2ref.mk \
 		mecat2cns/mecat2cns.mk \
+		mecat2cns/mecat2cns_gpu.mk \
 		filter_reads/filter_reads.mk

--- a/src/mecat2cns/dw.cu
+++ b/src/mecat2cns/dw.cu
@@ -1,0 +1,561 @@
+#include "dw.h"
+
+namespace ns_banded_sw {
+
+#define GAP_ALN 4
+
+SW_Parameters
+get_sw_parameters_small()
+{
+    SW_Parameters swp;
+    swp.segment_size = 500;
+    swp.row_size = 4096;
+    swp.column_size = 4096;
+    swp.segment_aln_size = 4096;
+    swp.max_seq_size = 100000;
+    swp.max_aln_size = 100000;
+    swp.d_path_size = 5000000;
+    swp.aln_path_size = 5000000;
+
+    return swp;
+}
+
+SW_Parameters
+get_sw_parameters_large()
+{
+    SW_Parameters swp;
+    swp.segment_size = 1000;
+    swp.row_size = 4096;
+    swp.column_size = 4096;
+    swp.segment_aln_size = 4096;
+    swp.max_seq_size = 100000;
+    swp.max_aln_size = 100000;
+    swp.d_path_size = 5000000;
+    swp.aln_path_size = 5000000;
+
+    return swp;
+}
+
+DiffRunningData::DiffRunningData(const SW_Parameters& swp_in)
+{
+	swp = swp_in;
+	safe_malloc(query, char, swp.max_seq_size);
+	safe_malloc(target, char, swp.max_seq_size);
+	safe_malloc(DynQ, int, swp.row_size);
+	safe_malloc(DynT, int, swp.column_size);
+	align = new Alignment(swp.segment_aln_size);
+	result = new OutputStore(swp.max_aln_size);
+	safe_malloc(d_path, DPathData2, swp.d_path_size);
+	safe_malloc(aln_path, PathPoint, swp.aln_path_size);
+}
+
+DiffRunningData::~DiffRunningData()
+{
+	safe_free(query);
+	safe_free(target);
+	safe_free(DynQ);
+	safe_free(DynT);
+	delete align;
+	delete result;
+	safe_free(d_path);
+	safe_free(aln_path);
+}
+
+void fill_m4record_from_output_store(const OutputStore& result, 
+									 const idx_t qid, 
+									 const idx_t sid,
+									 const char qstrand,
+									 const char sstrand,
+									 const idx_t qsize,
+									 const idx_t ssize,
+									 const idx_t q_off_in_aln, 
+									 const idx_t s_off_in_aln, 
+									 const idx_t q_ext,
+									 const idx_t s_ext,
+									 M4Record& m4)
+{
+	m4qid(m4) = qid;
+	m4sid(m4) = sid;
+	m4ident(m4) = result.ident;
+	m4vscore(m4) = 100;
+	m4qdir(m4) = 1 - (qstrand == 'F');
+	m4qoff(m4) = q_off_in_aln + result.query_start;
+	m4qend(m4) = q_off_in_aln + result.query_end;
+	m4qsize(m4) = qsize;
+	m4sdir(m4) = 1 - (sstrand == 'F');
+	m4soff(m4) = s_off_in_aln + result.target_start;
+	m4send(m4) = s_off_in_aln + result.target_end;
+	m4ssize(m4) = ssize;
+	m4qext(m4) = q_ext;
+	m4sext(m4) = s_ext;
+	
+	if (m4qdir(m4) == 1)
+	{
+		m4qoff(m4) = qsize - (q_off_in_aln + result.query_end);
+		m4qend(m4) = qsize - (q_off_in_aln + result.query_start);
+		m4qext(m4) = qsize - 1 - q_ext;
+	}
+	if (m4sdir(m4) == 1)
+	{
+		m4soff(m4) = ssize - (s_off_in_aln + result.target_end);
+		m4send(m4) = ssize - (s_off_in_aln + result.target_start);
+		m4sext(m4) = ssize - 1 - s_ext;
+	}
+}
+
+void print_candidate(const CandidateStartPosition& csp)
+{
+	std::cout << "qoff = " << csp.qoff
+			  << ", toff = " << csp.toff
+			  << ", tstart = " << csp.tstart
+			  << ", tsize = " << csp.tsize
+			  << ", tid = " << csp.tid
+			  << ", num1 = " << csp.num1
+			  << ", num2 = " << csp.num2
+			  << ", score = " << csp.score
+			  << ",  chain = " << csp.chain
+			  << ", l1 = " << csp.left_q
+			  << ", r1 = " << csp.right_q
+			  << ", l2 = " << csp.left_t
+			  << ", r2 = " << csp.right_t
+			  << "\n";
+}
+
+int CompareDPathData2(const void* a, const void* b)
+{
+    const DPathData2* d1 = (const DPathData2*)a;
+    const DPathData2* d2 = (const DPathData2*)b;
+    return (d1->d == d2->d) ? (d1->k - d2->k) : (d1->d - d2->d);
+}
+
+struct SCompareDPathData2
+{
+    bool operator()(const DPathData2& a, const DPathData2& b)
+    { return (a.d == b.d) ? (a.k < b.k) : (a.d < b.d); }
+};
+
+DPathData2* GetDPathIdx(const int d, const int k, const unsigned int max_idx, DPathData2* base)
+{
+    DPathData2 target;
+    target.d = d;
+    target.k = k;
+    DPathData2* ret = (DPathData2*)bsearch(&target, base, max_idx, sizeof(DPathData2), CompareDPathData2);
+    return ret;
+}
+
+//proof of concept 
+__global__ foo()
+{
+}
+
+int Align(const char* query, const int q_len, const char* target, const int t_len, 
+          const int band_tolerance, const int get_aln_str, Alignment* align, 
+		  int* V, int* U, DPathData2* d_path, PathPoint* aln_path, 
+		  const int right_extend, double error_rate)
+{
+    int k_offset;
+    int  d;
+    int  k, k2;
+    int best_m;
+    int min_k, new_min_k, max_k, new_max_k, pre_k;
+    int x, y;
+    int ck, cd, cx, cy, nx, ny; 
+    int max_d, band_size;
+    unsigned long d_path_idx = 0, max_idx = 0;
+    int aln_path_idx, aln_pos, i, aligned = 0;
+    DPathData2* d_path_aux;
+    
+    max_d = (int)(2.0 * error_rate * (q_len + t_len));
+    k_offset = max_d;
+    band_size = band_tolerance * 2;
+    align->init();
+    best_m = -1;
+    min_k = 0;
+    max_k = 0;
+    d_path_idx = 0;
+    max_idx = 0;
+    
+    foo<<<256, 256>>>(); 
+    for (d = 0; d < max_d; ++d)
+    {
+        if (max_k - min_k > band_size) break;
+
+        for (k = min_k; k <= max_k; k += 2)
+        {
+            if( k == min_k || (k != max_k && V[k - 1 + k_offset] < V[k + 1 + k_offset]) )
+            { pre_k = k + 1; x = V[k + 1 + k_offset]; }
+            else 
+            { pre_k = k - 1; x = V[k - 1 + k_offset] + 1; }
+            y = x - k;
+            d_path[d_path_idx].d = d;
+            d_path[d_path_idx].k = k;
+            d_path[d_path_idx].x1 = x;
+            d_path[d_path_idx].y1 = y;
+			
+			if (right_extend)
+				while( x < q_len && y < t_len && query[x] == target[y]) { ++x; ++y; }
+			else
+				while( x < q_len && y < t_len && query[-x] == target[-y]) { ++x; ++y; }
+
+            d_path[d_path_idx].x2 = x;
+            d_path[d_path_idx].y2 = y;
+            d_path[d_path_idx].pre_k = pre_k;
+            ++d_path_idx;
+
+            V[k + k_offset] = x;
+            U[k + k_offset] = x + y;
+            best_m = std::max(best_m, x + y);
+            if (x >= q_len || y >= t_len)
+            { aligned = 1; max_idx = d_path_idx; break; }
+        }
+
+        // for banding
+        new_min_k = max_k;
+        new_max_k = min_k;
+        for (k2 = min_k; k2 <= max_k; k2 += 2)
+            if (U[k2 + k_offset] >= best_m - band_tolerance)
+            { new_min_k = std::min(new_min_k, k2); new_max_k = std::max(new_max_k, k2); }
+        max_k = new_max_k + 1;
+        min_k = new_min_k - 1;
+
+        if (aligned)
+        {
+            align->aln_q_e = x;
+            align->aln_t_e = y;
+            align->dist = d;
+            align->aln_str_size = (x + y + d) / 2;
+            align->aln_q_s = 0;
+            align->aln_t_s = 0;
+
+            if (get_aln_str)
+            {
+                cd = d;
+                ck = k;
+                aln_path_idx = 0;
+                while (cd >= 0 && aln_path_idx < q_len + t_len + 1)
+                {
+                    d_path_aux = GetDPathIdx(cd, ck, max_idx, d_path);
+                    aln_path[aln_path_idx].x = d_path_aux->x2;
+                    aln_path[aln_path_idx].y = d_path_aux->y2;
+                    ++aln_path_idx;
+                    aln_path[aln_path_idx].x = d_path_aux->x1;
+                    aln_path[aln_path_idx].y = d_path_aux->y1;
+                    ++aln_path_idx;
+                    ck = d_path_aux->pre_k;
+                    cd -= 1;
+                }
+                --aln_path_idx;
+                cx = aln_path[aln_path_idx].x;
+                cy = aln_path[aln_path_idx].y;
+                align->aln_q_s = cx;
+                align->aln_t_s = cy;
+                aln_pos = 0;
+                while (aln_path_idx > 0)
+                {
+                    --aln_path_idx;
+                    nx = aln_path[aln_path_idx].x;
+                    ny = aln_path[aln_path_idx].y;
+                    if (cx == nx && cy == ny) continue;
+                    if (cx == nx && cy != ny)
+                    {
+						if (right_extend)
+						{
+							for (i = 0; i < ny - cy; ++i) align->q_aln_str[aln_pos + i] = GAP_ALN;
+							for (i = 0; i < ny - cy; ++i) align->t_aln_str[aln_pos + i] = target[cy + i];
+						}
+						else
+						{
+							for (i = 0; i < ny - cy; ++i) align->q_aln_str[aln_pos + i] = GAP_ALN;
+							for (i = 0; i < ny - cy; ++i) align->t_aln_str[aln_pos + i] = target[-(cy + i)];
+						}
+                        aln_pos += ny - cy;
+                    }
+                    else if (cx != nx && cy == ny)
+                    {
+						if (right_extend)
+						{
+							for (i = 0; i < nx - cx; ++i) align->q_aln_str[aln_pos + i] = query[cx + i];
+							for (i = 0; i < nx - cx; ++i) align->t_aln_str[aln_pos + i] = GAP_ALN;
+						}
+						else
+						{
+							for (i = 0; i < nx - cx; ++i) align->q_aln_str[aln_pos + i] = query[-(cx + i)];
+							for (i = 0; i < nx - cx; ++i) align->t_aln_str[aln_pos + i] = GAP_ALN;
+						}
+                        aln_pos += nx - cx;
+                    }
+                    else
+                    {
+						if (right_extend)
+						{
+							for (i = 0; i < nx - cx; ++i) align->q_aln_str[aln_pos + i] = query[cx + i];
+							for (i = 0; i < ny - cy; ++i) align->t_aln_str[aln_pos + i] = target[cy + i];
+						}
+						else
+						{
+							for (i = 0; i < nx - cx; ++i) align->q_aln_str[aln_pos + i] = query[-(cx + i)];
+							for (i = 0; i < ny - cy; ++i) align->t_aln_str[aln_pos + i] = target[-(cy + i)];
+						}
+                        aln_pos += ny - cy;
+                    }
+                    cx = nx;
+                    cy = ny;
+                }
+                align->aln_str_size = aln_pos;
+            }
+            break;
+        }
+    }
+    if (align->aln_q_e == q_len || align->aln_t_e == t_len) return 1;
+    else return 0;
+}
+
+void dw_in_one_direction(const char* query, const int query_size, const char* target, const int target_size,
+						 int* U, int* V, Alignment* align, DPathData2* d_path, PathPoint* aln_path, 
+						 SW_Parameters* swp, OutputStore* result, const int right_extend, double error_rate)
+{
+	const idx_t ALN_SIZE = swp->segment_size;
+	const idx_t U_SIZE = swp->row_size;
+	const idx_t V_SIZE = swp->column_size;
+    int extend1 = 0, extend2 = 0;
+    const char* seq1 = query;
+    const char* seq2 = target;
+    int extend_size = std::min(query_size, target_size);
+    int seg_size;
+    int flag_end = 1;
+    int align_flag;
+    int i, j, k, num_matches;
+    while (flag_end)
+    {
+        if (extend_size > (ALN_SIZE + 100))
+        { seg_size = ALN_SIZE; }
+        else
+        { seg_size = extend_size; flag_end = 0; }
+        memset(U, 0, sizeof(int) * U_SIZE);
+        memset(V, 0, sizeof(int) * V_SIZE);
+        if (right_extend) { seq1 = query + extend1; seq2 = target + extend2; }
+        else { seq1 = query - extend1; seq2 = target - extend2; }
+        align_flag = Align(seq1, seg_size, seq2, seg_size, 0.3 * seg_size, 400, align, U, V, d_path, aln_path, right_extend, error_rate);
+        if (align_flag)
+        {
+            for (k = align->aln_str_size - 1, i = 0, j = 0, num_matches = 0; k > -1 && num_matches < 4; --k)
+            {
+                if (align->q_aln_str[k] != GAP_ALN) ++i;
+                if (align->t_aln_str[k] != GAP_ALN) ++j;
+                if (align->q_aln_str[k] == align->t_aln_str[k]) ++num_matches;
+                else num_matches = 0;
+            }
+            if (flag_end)
+            {
+                i = ALN_SIZE - align->aln_q_e + i;
+                j = ALN_SIZE - align->aln_t_e + j;
+                if (i == ALN_SIZE) align_flag = 0;
+				extend1 = extend1 + ALN_SIZE - i; extend2 = extend2 + ALN_SIZE - j;
+            }
+            else
+            {
+                i = extend_size - align->aln_q_e;
+                j = extend_size - align->aln_t_e;
+                if (i == extend_size) align_flag = 0;
+				extend1 += (extend_size - i); extend2 += (extend_size - j);
+                k = align->aln_str_size - 1;
+            }
+            if (align_flag)
+            {
+                if (right_extend)
+                {
+                    memcpy(result->right_store1 + result->right_store_size, align->q_aln_str, k + 1);
+                    memcpy(result->right_store2 + result->right_store_size, align->t_aln_str, k + 1);
+                    result->right_store_size += (k + 1);
+                }
+                else
+                {
+                    memcpy(result->left_store1 + result->left_store_size, align->q_aln_str, k + 1);
+                    memcpy(result->left_store2 + result->left_store_size, align->t_aln_str, k + 1);
+                    result->left_store_size += (k + 1);
+                }
+                extend_size = std::min(query_size - extend1, target_size - extend2);
+            }
+        }
+        if (!align_flag) break;
+    }
+}
+
+int  dw(const char* query, const int query_size, const int query_start,
+        const char* target, const int target_size, const int target_start,
+        int* U, int* V, Alignment* align, DPathData2* d_path, 
+        PathPoint* aln_path, OutputStore* result, SW_Parameters* swp,
+	    double error_rate, const int min_aln_size)
+{
+    result->init();
+    align->init();
+    // left extend
+    dw_in_one_direction(query + query_start - 1, query_start,
+						target + target_start - 1, target_start,
+						U, V, align, d_path, aln_path, swp, result, 
+						0, error_rate);
+    align->init();
+    // right extend
+    dw_in_one_direction(query + query_start, query_size - query_start,
+						target + target_start, target_size - target_start,
+						U, V, align, d_path, aln_path, swp, result, 
+						1, error_rate);
+
+    // merge the results
+    int i, j, k, idx = 0;
+    const char* encode2char = "ACGT-";
+    for (k = result->left_store_size - 1, i = 0, j = 0; k > - 1; --k, ++idx)
+    {
+		unsigned char ch = result->left_store1[k];
+		r_assert(ch >= 0 && ch <= 4);
+		ch = encode2char[ch];
+		result->out_store1[idx] = ch;
+		if (ch != '-') ++i;
+		
+		ch = result->left_store2[k];
+		r_assert(ch >= 0 && ch <= 4);
+		ch = encode2char[ch];
+		result->out_store2[idx] = ch;
+		if (ch != '-')++j;
+    }
+    result->query_start = query_start - i;
+	if (result->query_start < 0)
+	{
+		std::cerr << "query_start = " << query_start << ", i = " << i << "\n";
+	}
+	r_assert(result->query_start >= 0);
+    result->target_start = target_start - j;
+	r_assert(result->target_start >= 0);
+    for (k = 0, i = 0, j = 0; k < result->right_store_size; ++k, ++idx)
+    {
+
+		unsigned char ch = result->right_store1[k];
+		r_assert(ch >= 0 && ch <= 4);
+		ch = encode2char[ch];
+		result->out_store1[idx] = ch;
+		if (ch != '-') ++i;
+		
+		ch = result->right_store2[k];
+		r_assert(ch >= 0 && ch <= 4);
+		ch = encode2char[ch];
+		result->out_store2[idx] = ch;
+		if (ch != '-') ++j;
+    }
+    result->out_store_size = idx;
+    result->query_end = query_start + i;
+    result->target_end = target_start + j;
+
+	if (result->out_store_size >= min_aln_size)
+    {
+        int mat = 0, mis = 0, ins = 0, del = 0;
+        for (j = 0; j < result->out_store_size; ++j)
+        {
+            if (result->out_store1[j] == result->out_store2[j])
+            {
+                ++mat;
+                result->out_match_pattern[j] = '|';
+            }
+            else if (result->out_store1[j] == '-')
+            {
+                ++ins;
+                result->out_match_pattern[j] = '*';
+            }
+            else if (result->out_store2[j] == '-')
+            {
+                ++del;
+                result->out_match_pattern[j] = '*';
+            }
+            else
+            {
+                ++mis;
+                result->out_match_pattern[j] = '*';
+            }
+        }
+        result->out_store1[result->out_store_size] = '\0';
+        result->out_store2[result->out_store_size] = '\0';
+        result->out_match_pattern[result->out_store_size] = '\0';
+        result->mat = mat;
+        result->mis = mis;
+        result->ins = ins;
+        result->del = del;
+        result->ident = 100.0 * mat / result->out_store_size;
+
+        return 1;
+    }
+    return 0;
+}
+
+bool GetAlignment(const char* query, const int query_start, const int query_size,
+				  const char* target, const int target_start, const int target_size,
+				  DiffRunningData* drd, M5Record& m5, double error_rate,
+				  const int min_aln_size)
+{
+	int flag = dw(query, query_size, query_start,
+				  target, target_size, target_start,
+				  drd->DynQ, drd->DynT, 
+				  drd->align, drd->d_path,
+				  drd->aln_path, drd->result,
+				  &drd->swp, error_rate, min_aln_size);
+	if (!flag) return false;
+	
+	int qrb = 0, qre = 0;
+	int trb = 0, tre = 0;
+	int eit = 0, k = 0;
+	const int consecutive_match_region_size = 4;
+	for (k = 0; k < drd->result->out_store_size && eit < consecutive_match_region_size; ++k)
+	{
+		const char qc = drd->result->out_store1[k];
+		const char tc = drd->result->out_store2[k];
+		if (qc != '-') ++qrb;
+		if (tc != '-') ++trb;
+		if (qc == tc) ++eit;
+		else eit = 0;
+	}
+	if (eit < consecutive_match_region_size) return false;
+	k -= consecutive_match_region_size;
+	qrb -= consecutive_match_region_size;
+	trb -= consecutive_match_region_size;
+	const int start_aln_id = k;
+	if (start_aln_id < 0)
+	{
+		std::cout << qrb << "\t" << trb << "\t" << eit << "\t" << k << "\n";
+	}
+	
+	for (k = drd->result->out_store_size - 1, eit = 0; k >= 0 && eit < consecutive_match_region_size; --k)
+	{
+		const char qc = drd->result->out_store1[k];
+		const char tc = drd->result->out_store2[k];
+		if (qc != '-') ++qre;
+		if (tc != '-') ++tre;
+		if (qc == tc) ++eit;
+		else eit = 0;
+	}
+	if (eit < consecutive_match_region_size) return false;
+	k += consecutive_match_region_size;
+	qre -= consecutive_match_region_size;
+	tre -= consecutive_match_region_size;
+	const int end_aln_id = k + 1;
+	
+	m5qsize(m5) = query_size;
+	m5qoff(m5) = drd->result->query_start + qrb;
+	m5qend(m5) = drd->result->query_end - qre;
+	m5qdir(m5) = FWD;
+
+	m5ssize(m5) = target_size;
+	m5soff(m5) = drd->result->target_start + trb;
+	m5send(m5) = drd->result->target_end - tre;
+	m5sdir(m5) = FWD;
+
+	const int aln_size = end_aln_id - start_aln_id;
+
+	memcpy(m5qaln(m5), drd->result->out_store1 + start_aln_id, aln_size);
+	memcpy(m5saln(m5), drd->result->out_store2 + start_aln_id, aln_size);
+	memcpy(m5pat(m5), drd->result->out_match_pattern + start_aln_id, aln_size);
+	m5qaln(m5)[aln_size] = '\0';
+	m5saln(m5)[aln_size] = '\0';
+	m5pat(m5)[aln_size] = '\0';
+	
+	return true;
+}
+
+} // end namespace ns_banded_sw

--- a/src/mecat2cns/dw_cuda.cu
+++ b/src/mecat2cns/dw_cuda.cu
@@ -144,7 +144,7 @@ DPathData2* GetDPathIdx(const int d, const int k, const unsigned int max_idx, DP
 }
 
 //proof of concept 
-__global__ foo()
+__global__ void foo()
 {
 }
 

--- a/src/mecat2cns/mecat2cns.mk
+++ b/src/mecat2cns/mecat2cns.mk
@@ -5,8 +5,10 @@ ifeq "$(strip ${TARGET_DIR})" ""
   TARGET_DIR   := ../$(OSTYPE)-$(MACHINETYPE)/bin
 endif
 
-TARGET   := mecat2cns
-SOURCES  := main.cpp \
+TARGET       := mecat2cns
+SRC_CXXFLAGS := -D_GLIBCXX_PARALLEL -pthread -fopenmp
+
+SOURCES      := main.cpp \
 	argument.cpp \
 	dw.cpp \
 	MECAT_AlnGraphBoost.C \
@@ -19,7 +21,7 @@ SOURCES  := main.cpp \
 
 SRC_INCDIRS  := . libboost
 
-TGT_LDFLAGS := -L${TARGET_DIR}
+TGT_LDFLAGS := -L${TARGET_DIR} -pthread -lm -fopenmp 
 TGT_LDLIBS  := -lmecat
 TGT_PREREQS := libmecat.a
 

--- a/src/mecat2cns/mecat2cns_gpu.mk
+++ b/src/mecat2cns/mecat2cns_gpu.mk
@@ -1,0 +1,30 @@
+ifeq "$(strip ${BUILD_DIR})" ""
+  BUILD_DIR    := ../$(OSTYPE)-$(MACHINETYPE)/obj
+endif
+ifeq "$(strip ${TARGET_DIR})" ""
+  TARGET_DIR   := ../$(OSTYPE)-$(MACHINETYPE)/bin
+endif
+
+TARGET   := mecat2cns_gpu 
+TGT_LINKER := nvcc 
+
+SRC_CXXFLAGS := -pthread -D_GLIBCXX_PARALLEL -fopenmp
+
+SOURCES  := main.cpp \
+	argument.cpp \
+	dw.cu \
+	MECAT_AlnGraphBoost.C \
+	mecat_correction.cpp \
+	options.cpp \
+	overlaps_partition.cpp \
+	reads_correction_aux.cpp \
+	reads_correction_can.cpp \
+	reads_correction_m4.cpp \
+
+SRC_INCDIRS  := . libboost
+
+TGT_LDFLAGS := -L${TARGET_DIR} -Xcompiler="-pthread" -lm -Xcompiler="-fopenmp"
+TGT_LDLIBS  := -lmecat
+TGT_PREREQS := libmecat.a
+
+SUBMAKEFILES :=

--- a/src/mecat2cns/mecat2cns_gpu.mk
+++ b/src/mecat2cns/mecat2cns_gpu.mk
@@ -5,6 +5,7 @@ ifeq "$(strip ${TARGET_DIR})" ""
   TARGET_DIR   := ../$(OSTYPE)-$(MACHINETYPE)/bin
 endif
 
+NVCC    := nvcc 
 TARGET   := mecat2cns_gpu 
 TGT_LINKER := nvcc 
 
@@ -12,7 +13,7 @@ SRC_CXXFLAGS := -pthread -D_GLIBCXX_PARALLEL -fopenmp
 
 SOURCES  := main.cpp \
 	argument.cpp \
-	dw.cu \
+	dw_cuda.cu \
 	MECAT_AlnGraphBoost.C \
 	mecat_correction.cpp \
 	options.cpp \

--- a/src/mecat2cns/mecat_correction.cpp
+++ b/src/mecat2cns/mecat_correction.cpp
@@ -11,10 +11,10 @@ namespace ns_meap_cns {
 #define FINS 4
 #define UNDS 8
 
-inline uint1
+inline u1_t
 identify_one_consensus_item(CnsTableItem& cns_item, const int min_cov)
 {
-	uint1 ident = 0;
+	u1_t ident = 0;
 	int cov = cns_item.mat_cnt + cns_item.ins_cnt;
 	if (cns_item.mat_cnt >= cov * 0.8) ident |= FMAT;
 	if (cns_item.ins_cnt >= cov * 0.8) ident |= FINS;
@@ -79,7 +79,7 @@ meap_cns_one_indel(const int sb, const int se, CnsAlns& cns_vec,
 
 void
 meap_consensus_one_segment(CnsTableItem* cns_list, const int cns_list_size, 
-						   uint1* cns_id_vec,
+						   u1_t* cns_id_vec,
 						   int start_soff, CnsAlns& cns_vec, 
 						   std::string& aux_qstr, std::string& aux_tstr,
 						   std::string& target, const int min_cov)
@@ -201,7 +201,7 @@ check_ovlp_mapping_range(const int qb, const int qe, const int qs,
 
 void
 consensus_worker(CnsTableItem* cns_table,
-				 uint1* id_list,
+				 u1_t* id_list,
 				 CnsAlns& cns_vec,
 				 std::string& aux_qstr,
 				 std::string& aux_tstr,

--- a/src/mecat2cns/reads_correction_aux.h
+++ b/src/mecat2cns/reads_correction_aux.h
@@ -11,9 +11,9 @@
 struct CnsTableItem
 {
 	char base;
-	uint1 mat_cnt;
-	uint1 ins_cnt;
-	uint1 del_cnt;
+	u1_t mat_cnt;
+	u1_t  ins_cnt;
+	u1_t del_cnt;
 	
 	CnsTableItem() : base('N'), mat_cnt(0), ins_cnt(0), del_cnt(0) {}
 };
@@ -127,7 +127,7 @@ struct ConsensusThreadData
 	std::string qaln;
 	std::string saln;
 	CnsTableItem* cns_table;
-	uint1* id_list;
+	u1_t* id_list;
 	std::ostream* out;
 	pthread_mutex_t out_lock;
 	
@@ -148,7 +148,7 @@ struct ConsensusThreadData
 		qaln.reserve(MAX_SEQ_SIZE);
 		saln.reserve(MAX_SEQ_SIZE);
 		safe_malloc(cns_table, CnsTableItem, MAX_SEQ_SIZE);
-		safe_malloc(id_list, uint1, MAX_SEQ_SIZE);
+		safe_malloc(id_list, u1_t, MAX_SEQ_SIZE);
 		pthread_mutex_init(&out_lock, NULL);
 	}
 	

--- a/src/mecat2pw/pw.mk
+++ b/src/mecat2pw/pw.mk
@@ -8,9 +8,10 @@ endif
 TARGET   := mecat2pw
 SOURCES  := pw.cpp pw_impl.cpp pw_options.cpp
 
+SRC_CXXFLAGS := -pthread -D_GLIBCXX_PARALLEL -fopenmp 
 SRC_INCDIRS  := ../common .
 
-TGT_LDFLAGS := -L${TARGET_DIR}
+TGT_LDFLAGS := -L${TARGET_DIR} -pthread -fopenmp
 TGT_LDLIBS  := -lmecat
 TGT_PREREQS := libmecat.a
 

--- a/src/mecat2ref/mecat2ref.mk
+++ b/src/mecat2ref/mecat2ref.mk
@@ -10,7 +10,7 @@ SOURCES  := mecat2ref.cpp mecat2ref_impl_large.cpp output.cpp mecat2ref_aux.cpp
 
 SRC_INCDIRS  := . 
 
-TGT_LDFLAGS := -L${TARGET_DIR}
+TGT_LDFLAGS := -L${TARGET_DIR} -pthread -fopenmp 
 TGT_LDLIBS  := -lmecat
 TGT_PREREQS := libmecat.a
 


### PR DESCRIPTION
Adds a new make target: mecat2cns_gpu.
  - Uses dw.cu instead of dw.cpp for building.
 
Now when we make, we'll have two versions of the tool - meecat2cns and meecat2cns_gpu so they can race.