### PR TITLE
Diff check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,9 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-# Test results
+# Test artifcats
 test/test_results*
+test/work
+test/diff_work
+test/diff_report
+test/*.fasta

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ test/work
 test/diff_work
 test/diff_report
 test/*.fasta
+test/*.short

--- a/test/benchMecat.sh
+++ b/test/benchMecat.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 
-# Runs MECAT: mecat2cns on test data 
+# Runs MECAT: mecat2cns on test data
 #
-# $1 - path to fasta input 
+# $1 - path to fasta input
 #
-# Compares gpu version performance with cpu version 
+# Compares gpu version performance with cpu version
 
-#Assumes you're on the alienware server... 
-# TODO - generalize 
+#Assumes you're on the alienware server...
+# TODO - generalize
 mecat_bin=../Linux-amd64/bin
 
 work="./work"
-mkdir -p $work 
+mkdir -p $work
 
-#Check input 
+#Check input
 if [ "$#" -ne 1 ]; then
-    echo "Usage: ./testMecat.sh input.fasta"  
+    echo "Usage: ./testMecat.sh input.fasta"
     exit 1
-fi 
+fi
 
-if [ ! -f $1 ]; then 
+if [ ! -f $1 ]; then
     echo "File: $1 does not exist"
     exit 1
 fi
 fasta_in=$1 #./MAP006-PCR-1_2D_pass.fasta
 
-#local variables 
+#local variables
 candidate="./$work/candidate.txt"
 fasta_mid="./$work/corrected_ecoli.fasta"
 fasta_ext="./$work/corrected_ecolix25"
@@ -47,7 +47,7 @@ mecat2cns_gpu -i 0 -t 1 -x 1 $candidate $fasta_in $fasta_mid.gpu
 gpu_p=$(date +%s)
 
 
-#report results 
+#report results
 let gpu_time=( $gpu_p - $gpu_s )
 let cpu_time=( $cpu_p - $cpu_s )
 
@@ -59,7 +59,7 @@ echo "GPU size: $(ls -sh $fasta_mid".gpu")" | tee -a $results
 echo "CPU size: $(ls -sh $fasta_mid".cpu")" | tee -a $results
 
 #delete run artifacts
-rm -rf $work 
+rm -rf $work
 
 
 #Ignore other steps for now... compare file sizes of output until a better output validation metric is needed

--- a/test/diffCheck.sh
+++ b/test/diffCheck.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Runs MECAT: mecat2cns multiple times to compare gpu and cpu output
+#
+# $1 - path to fasta input
+
+#won't work if you have more than one bin dir under MECAT
+mecat_bin=$(realpath $(find .. -name "bin"))
+
+#Check input args
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ./testMecat.sh input.fasta"
+    exit 1
+fi
+
+if [ ! -f $1 ]; then
+    echo "Expected fasta input file: $1 does not exist"
+    exit 1
+fi
+fasta_in=$1
+
+#local variables
+work=$(realpath "./diff_work")
+mkdir -p $work
+candidate="$work/candidate.txt"
+fasta_mid="$work/corrected_ecoli.fasta"
+
+#some commands rely on having mecat's bin in the path
+export PATH="$PATH:$mecat_bin"
+
+#do first step
+mecat2pw -j 0 -d $fasta_in -o $candidate -w $work -t 12 -x 1
+
+#Perform calculation on cpu and gpu to look at outputs
+mecat2cns -i 0 -t 1 -x 1 $candidate $fasta_in $fasta_mid.cpu
+mecat2cns_gpu -i 0 -t 1 -x 1 $candidate $fasta_in $fasta_mid.gpu
+
+diff $fasta_mid.cpu $fasta_mid.gpu > diff_report
+
+if [ $? -eq 1 ]; then
+    echo "GPU and CPU outputs differ. Check diff_report for details."
+    exit 1
+else
+    rm diff_report
+    exit 0
+fi

--- a/test/diffCheck.sh
+++ b/test/diffCheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Runs MECAT: mecat2cns multiple times to compare gpu and cpu output
+# compare mecat2cns and mecat2cns_gpu outpt. Fails if they differ
 #
 # $1 - path to fasta input
 
@@ -38,9 +38,10 @@ mecat2cns_gpu -i 0 -t 1 -x 1 $candidate $fasta_in $fasta_mid.gpu
 diff $fasta_mid.cpu $fasta_mid.gpu > diff_report
 
 if [ $? -eq 1 ]; then
-    echo "GPU and CPU outputs differ. Check diff_report for details."
+    echo "GPU and CPU outputs differ. Check diff_report and diff_work for details."
     exit 1
 else
     rm diff_report
+    rm -rf $work
     exit 0
 fi


### PR DESCRIPTION
I added a new test to compare the outputs of mecat2cns and mecat2cns_gpu.

There's a new pre-push git hook to go with it over at https://github.com/30Wedge/git_hooks.
 
The hook looks for a .fasta file in MECAT/test, if it can't find one it downloads the ecoli example reads for you.
The pre-push hook only takes the first 1k reads from the fasta, which keeps this test's runtime < 1 minute.
